### PR TITLE
fix build for el7

### DIFF
--- a/python-httmock.spec
+++ b/python-httmock.spec
@@ -22,7 +22,7 @@ Source0: %{pkgname}-%{version}.tar.gz
 
 Requires: python-requests >= 1.0.0
 BuildRequires: python-requests >= 1.0.0
-BuildRequires: python-nose%{nose_version}
+BuildRequires: python-nose%{nose_version}, python2-devel
 
 BuildArch: noarch
 

--- a/python-httmock.spec
+++ b/python-httmock.spec
@@ -13,7 +13,7 @@
 Name: python-%{pkgname}
 Summary: A mocking library for requests
 Version: 1.2.3
-Release: 1%{?dist}
+Release: 2%{?dist}
 License: Apache License, Version 2.0
 
 Group: Development/Testing
@@ -50,6 +50,9 @@ rm -rf %{buildroot}
 %doc README.md LICENSE
 
 %changelog
+* Fri Jun 03 2016 Vladislav Odintsov <odivlad@gmail.com> 1.2.3-2
+- Fix build for el7 distros
+
 * Mon Mar 16 2015 Mikhail Ushanov <gm.mephisto@gmail.com> 1.2.3-1
 - Update version.
 


### PR DESCRIPTION
This is done due to koji build errors for `el7` distro:

```
Executing(%prep): /bin/sh -e /var/tmp/rpm-tmp.YKvxYD
+ umask 022
+ cd /builddir/build/BUILD
+ cd /builddir/build/BUILD
+ rm -rf httmock-1.2.3
+ /usr/bin/gzip -dc /builddir/build/SOURCES/httmock-1.2.3.tar.gz
+ /usr/bin/tar -xf -
+ STATUS=0
+ '[' 0 -ne 0 ']'
+ cd httmock-1.2.3
+ /usr/bin/chmod -Rf a+rX,u+w,g-w,o-w .
+ exit 0
Executing(%build): /bin/sh -e /var/tmp/rpm-tmp.Q8JHs2
+ umask 022
+ cd /builddir/build/BUILD
+ cd httmock-1.2.3
+ '%{__python2}' setup.py build
/var/tmp/rpm-tmp.Q8JHs2: line 29: fg: no job control
error: Bad exit status from /var/tmp/rpm-tmp.Q8JHs2 (%build)
RPM build errors:
    Bad exit status from /var/tmp/rpm-tmp.Q8JHs2 (%build)
Child return code was: 1
EXCEPTION: Command failed. See logs for output.
 # bash --login -c /usr/bin/rpmbuild -bb --target noarch --nodeps  /builddir/build/SPECS/python-httmock.spec 
Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/mockbuild/trace_decorator.py", line 84, in trace
    result = func(*args, **kw)
  File "/usr/lib/python2.6/site-packages/mockbuild/util.py", line 526, in do
    raise exception.Error("Command failed. See logs for output.\n # %s" % (command,), child.returncode)
Error: Command failed. See logs for output.
 # bash --login -c /usr/bin/rpmbuild -bb --target noarch --nodeps  /builddir/build/SPECS/python-httmock.spec 
LEAVE do --> EXCEPTION RAISED
```

`el6` distros are build successfully with these changes.
